### PR TITLE
Remove '@' from scoped package names

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function resolveModuleName(request, issuer, compilerOptions, moduleResolutionHos
 
   // First we try the resolution on "@types/package-name" starting from the project root
   if (packageName) {
-    const typesPackagePath = `@types/${packageName.replace(/\//g, `__`)}${rest}`;
+    const typesPackagePath = `@types/${packageName.replace(/\//g, `__`).replace('@', '')}${rest}`;
 
     let unqualified;
     try {


### PR DESCRIPTION
The name of scoped packages `"@scope/package"` are currently transformed to `"@types/@scope__package"`.

`/` is handled correctly, but not `@`.